### PR TITLE
Update certificate-governance.md

### DIFF
--- a/guides/certificate-governance.md
+++ b/guides/certificate-governance.md
@@ -149,7 +149,7 @@ The following table gives guidance on the NB<sub>CSCA</sub> certificate template
 |Field | Value|
 |------| -----|
 |**Subject**|	**cn**= \<Country\> DGC CSCA \<counter starting at 1\>, ou=\<Organizational Unit of Country\>, o=\<Provider\> ,**c=\<Member State operating the CSCA\>**, e= \<contact email\>|
-|**Key Usage**|	**digital signature, certificate signing**, CRL signing|
+|**Key Usage**|	**certificate signing**, CRL signing|
 |**Basic Constraints**|	**CA = true, path length constraints = 0**
 
 In accordance to [2, Section 5], the subject name must be non-empty and unique within the specified country. The country code (c) must match the country that will use this CSCA. The certificate must contain a unique subject key identifier (SKI) according to RFC 5280. 


### PR DESCRIPTION
section 4.2	CSCA certificate 
PROPOSED CHANGE: Remove the keyUsage bit "digitalSignature"
REASON: The CA uses its key for signing certificates and maybe CRLs. The CA is NOT supposed to sign other data.
Quote from RFC 5280:  The digitalSignature bit is asserted when the subject public key is used for verifying digital signatures, other than signatures on certificates (bit 5) and CRLs (bit 6), such as those used in an entity authentication service, a data origin authentication service, and/or an integrity service.
[...]
If the subject public key is only to be used for verifying signatures on certificates and/or CRLs, then the digitalSignature and nonRepudiation bits SHOULD NOT be set.  However, the digitalSignature and/or nonRepudiation bits MAY be set in addition to the keyCertSign and/or cRLSign bits if the subject public key is to be used to verify signatures on certificates and/or CRLs as well as other objects