### PR TITLE
Update certificate-governance.md

### DIFF
--- a/guides/certificate-governance.md
+++ b/guides/certificate-governance.md
@@ -182,8 +182,8 @@ The following table provides guidance for the national backend upload certificat
 The following table provides guidance for the national backend TLS client authentication certificate.
 |Field | Value|
 |------| -----|
-|**Subject**|	**cn=\<common name of the NB\>**, ou=\<Organizational Unit of Country\>, **o=\<Provider\>**, **c= \<Member State of the NB\>**, e= \<contact email\>
-|**SubjectAltName**|**dnsName: \<NB DNS name\>**
+|**Subject**|	**cn=\<FQDN or IP address of the NB TLS client\>**, **o=\<Provider\>**, **c= \<Member State of the NB\>**
+|**SubjectAltName**|dnsName: \<NB DNS name\>, iPAddress: \<NB IP address\>
 |**Key Usage**	| **digital signature**, key encipherment
 |**Extended Key Usage**|	**server authentication (1.3.6.1.5.5.7.3.1), client authentication (1.3.6.1.5.5.7.3.2)**
 
@@ -198,8 +198,8 @@ The TLS certificate of the NB must be issued by a publicly trusted certificate a
 ## 4.7	DGCG TLS Server certificates (DGCG<sub>TLS</sub>)
 |Field | Value|
 |------| -----|
-|**Subject**|	**cn=\<Common Name of the DGCG\>**, ou=\<Organizational Unit of Country\>, o=\<Provider\> ,**c= \<country\>**, e= \<contact email\>
-|**SubjectAltName**|**dnsName: \<DGCG DNS name\>**
+|**Subject**|	**cn=\<FQDN or IP address of the DGCG\>**, **o=\<Provider\> ,**c= \<country\>**
+|**SubjectAltName**|dnsName: \<DGCG DNS name\>, iPAddress: \<DGCG IP address\>
 |**Key Usage**|	**digital signature**, key encipherment
 |**Extended Key Usage**|	**server authentication (1.3.6.1.5.5.7.3.1), client authentication (1.3.6.1.5.5.7.3.2)**
 


### PR DESCRIPTION
section 4.5 National Backend TLS Client Authentication  AND section 4.7 DGCG TLS Server certificates
PROPOSED CHANGES: 
- The CN in the subject MUST be a FQDN or IP Address
- Remove the OU attribute. It is optional according to the CA/B Forum, but public CAs have deprecated this attribute last year (e.g. DigiCert)
- Remove mail attribute
- SAN can be either a FQDN or an IP address

REASON: The subject and SAN are not aligned with the CA/B Forum Baseline Requirements. 
https://cabforum.org/wp-content/uploads/CA-Browser-Forum-BR-1.7.4.pdf, section 7.1.4.2.2 Subject Distinguished Name Fields: and 7.1.4.2.1 Subject Alternative Name Extension
- Certificate Field: subject:commonName (OID 2.5.4.3)
  Required/Optional: Deprecated (Discouraged, but not prohibited)
  Contents: If present, this field MUST contain a single IP address or Fully‐Qualified Domain Name that is one of the values contained in the Certificate’s subjectAltName extension 

- Certificate Field: extensions:subjectAltName
  Required/Optional: Required
  Contents: This extension MUST contain at least one entry. Each entry MUST be either a dNSName containing the Fully‐Qualified Domain Name or an iPAddress containing the IP address of a server. The CA MUST confirm that the Applicant controls the Fully‐Qualified Domain Name or IP address or has been granted the right to use it by the Domain Name Registrant or IP address assignee, as appropriate