### PR TITLE
Default branch for contribution is main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ The following rule governs documentation contributions:
 
 ## Pull Request Checklist
 
-* Branch from the master branch and, if needed, rebase to the current master branch before submitting your pull request. If it doesn't merge cleanly with master you may be asked to rebase your changes.
+* Branch from the main branch and, if needed, rebase to the current main branch before submitting your pull request. If it doesn't merge cleanly with main you may be asked to rebase your changes.
 
 * Commits should be as small as possible while ensuring that each commit is correct independently (i.e., each commit should compile and pass tests).
 


### PR DESCRIPTION
@daniel-eder @SchulzeStTSI

This PR corrects the file https://github.com/eu-digital-green-certificates/dgc-overview/blob/main/CONTRIBUTING.md which currently refers to the "master" branch. The "master" branch however does not exist. GitHub has generally transitioned from using "master" to using "main" as the default branch, and this is the way that this depository has been created.

(See https://docs.github.com/en/github/getting-started-with-github/github-glossary#master.)

Under [Pull Request Checklist](https://github.com/eu-digital-green-certificates/dgc-overview/blob/main/CONTRIBUTING.md#pull-request-checklist) the first bullet point is changed to:

- Branch from the **main** branch and, if needed, rebase to the current **main** branch before submitting your pull request. If it doesn't merge cleanly with **main** you may be asked to rebase your changes.