### PR TITLE
fix(dgc-cms-migration):Fixing import on python script for pkcs7. @eu-digital-green-certificates/dgc-overview-members

### DIFF
--- a/cms-migration/cmsmig.py
+++ b/cms-migration/cmsmig.py
@@ -35,6 +35,7 @@ from cryptography import x509
 from argparse import ArgumentParser
 from base64 import b64encode, b64decode
 from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.serialization import pkcs7
 
 def main(args):
     if not args.environment.upper() in baseurls: 


### PR DESCRIPTION
## Description
Out of the box the script is looking for pkcs7, It does not seem to be imported when bringing in the `serialization` from `cryptography.hazmat.primitives`

This change is to explicitly specify `pkcs7` from  `cryptography.hazmat.primitives.serialization`

<img width="1715" alt="image" src="https://github.com/eu-digital-green-certificates/dgc-overview/assets/91917176/8a3f0818-f3eb-4b7d-9eeb-ded490715a67">
